### PR TITLE
Feature/add title to csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 .idea/
-mangas.txt
+.vscode/
+testDir/
+mangas.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -139,7 +139,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.11.1",
  "signal-hook",
  "winapi",
 ]
@@ -163,7 +163,7 @@ dependencies = [
  "dtoa-short",
  "itoa",
  "matches",
- "phf",
+ "phf 0.8.0",
  "proc-macro2",
  "quote",
  "smallvec",
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafcf38a1a36118242d29b92e1b08ef84e67e4a5ed06e0a80be20e6a32bfed6b"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
 dependencies = [
  "log",
  "mac",
@@ -608,10 +608,11 @@ checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -648,13 +649,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
- "phf",
- "phf_codegen",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -757,12 +758,12 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "open"
-version = "2.0.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46b233de7d83bc167fe43ae2dda3b5b84e80e09cceba581e4decb958a4896bf"
+checksum = "360bcc8316bf6363aa3954c3ccc4de8add167b087e0259190a043c9514f910fe"
 dependencies = [
  "pathdiff",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -806,7 +807,17 @@ checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.3",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -821,6 +832,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -851,8 +875,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.8.0",
  "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -861,8 +894,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -871,8 +914,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.8.0",
  "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -881,8 +934,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -894,6 +947,15 @@ name = "phf_shared"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
@@ -1136,6 +1198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,9 +1227,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scraper"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e02aa790c80c2e494130dec6a522033b6a23603ffc06360e9fe6c611ea2c12"
+checksum = "5684396b456f3eb69ceeb34d1b5cb1a2f6acf7ca4452131efa3ba0ee2c2d0a70"
 dependencies = [
  "cssparser",
  "ego-tree",
@@ -1208,8 +1276,8 @@ dependencies = [
  "fxhash",
  "log",
  "matches",
- "phf",
- "phf_codegen",
+ "phf 0.8.0",
+ "phf_codegen 0.8.0",
  "precomputed-hash",
  "servo_arc",
  "smallvec",
@@ -1236,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 
 [[package]]
 name = "serde_json"
@@ -1265,23 +1333,27 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "0.5.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
 dependencies = [
+ "futures",
  "lazy_static",
- "parking_lot",
+ "log",
+ "parking_lot 0.12.1",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "0.5.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
 dependencies = [
+ "proc-macro-error",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -1357,7 +1429,7 @@ checksum = "8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "phf_shared",
+ "phf_shared 0.8.0",
  "precomputed-hash",
  "serde",
 ]
@@ -1368,8 +1440,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
  "proc-macro2",
  "quote",
 ]
@@ -1489,7 +1561,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.1",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -1757,6 +1829,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scraper = "0.12.0"
-reqwest = { version = "0.11.6" }
-tokio = { version = "1.14.0", features = ["full"] }
-futures = "0.3.18"
-structopt = "0.3.25"
-csv = "1.1.6"
 colour = "0.6.0"
+csv = "1.1.6"
+futures = "0.3.18"
+open = "3.0.1"
+reqwest = { version = "0.11.6" }
+scraper = "0.13.0"
+serial_test = "0.8.0"
+structopt = "0.3.25"
 text_io = "0.1.9"
-open = "2.0.1"
-serial_test = "0.5.1"
+tokio = { version = "1.14.0", features = ["full"] }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -16,7 +16,7 @@ pub async fn add_new_manga(path: Option<PathBuf>,  manga_url: &str, verbose: boo
             if !is_present {
                 match find_last_chapter(manga_url, None, &verbose).await {
                     Ok(last_chapter) => {
-                        match append_to_file(path, manga_url, last_chapter.num) {
+                        match append_to_file(path, manga_url, last_chapter.num, last_chapter.manga_title.as_str()) {
                             Ok(_) => println!("The manga has been added."),
                             Err(e) => eprintln!("Error during the add : {}", e)
                         }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -87,12 +87,12 @@ mod tests {
         current.push(CSVLine {
             url: "url1".to_string(),
             last_chapter_num: 1.0,
-            title: "title3".to_string(),
+            title: "title1".to_string(),
         });
         current.push(CSVLine {
             url: "url3".to_string(),
             last_chapter_num: 3.0,
-            title: "title4".to_string(),
+            title: "title3".to_string(),
         });
         assert_eq!(imported.get(0), current.get(0));
         let result = find_new_lines(imported.clone(), current.clone());

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
-use crate::models::CSVLine;
-use std::io;
 use crate::file_ops::read_csv;
 use crate::file_ops::write_file::update_csv;
+use crate::models::CSVLine;
+use std::io;
+use std::path::PathBuf;
 
 /// Imports a CSV file corresponding to the one used by the program.
 /// It can either overwrite or just append to the current file, depending on the `overwrite` parameter.
@@ -15,7 +15,12 @@ use crate::file_ops::write_file::update_csv;
 /// # Returns:
 /// This function returns `true` if no errors happened, or `false` if the import file was not set.
 /// An I/O Error will simply be carried over to the calling function.
-pub fn import_file(from: Option<PathBuf>, to: Option<PathBuf>, overwrite: bool, verbose: bool) -> Result<bool, io::Error> {
+pub fn import_file(
+    from: Option<PathBuf>,
+    to: Option<PathBuf>,
+    overwrite: bool,
+    verbose: bool,
+) -> Result<bool, io::Error> {
     match from {
         Some(from_path) => {
             let imported_lines = read_csv(&Some(from_path), &verbose)?;
@@ -33,7 +38,7 @@ pub fn import_file(from: Option<PathBuf>, to: Option<PathBuf>, overwrite: bool, 
                 update_csv(&to, update)?;
             }
             Ok(true)
-        },
+        }
         None => {
             eprintln!("No file specified. Please use import -e [file] to import.");
             Ok(false)
@@ -50,10 +55,11 @@ pub fn import_file(from: Option<PathBuf>, to: Option<PathBuf>, overwrite: bool, 
 /// # Returns:
 /// A new Vec containing the old lines wih the new ones appended behind.
 fn find_new_lines(imported: Vec<CSVLine>, current: Vec<CSVLine>) -> Vec<CSVLine> {
-    let old_urls: Vec<_> = current.clone().into_iter()
-        .map(|line| line.url).collect();
-    let filtered_import: Vec<CSVLine> = imported.into_iter()
-        .filter(|line| !old_urls.contains(&line.url)).collect();
+    let old_urls: Vec<_> = current.clone().into_iter().map(|line| line.url).collect();
+    let filtered_import: Vec<CSVLine> = imported
+        .into_iter()
+        .filter(|line| !old_urls.contains(&line.url))
+        .collect();
 
     let mut result = current;
     result.extend(filtered_import);
@@ -69,20 +75,24 @@ mod tests {
         let mut imported: Vec<CSVLine> = Vec::new();
         imported.push(CSVLine {
             url: "url1".to_string(),
-            last_chapter_num: 1.0
+            last_chapter_num: 1.0,
+            title: "title1".to_string(),
         });
         imported.push(CSVLine {
             url: "url2".to_string(),
-            last_chapter_num: 2.0
+            last_chapter_num: 2.0,
+            title: "title2".to_string(),
         });
-        let mut current : Vec<CSVLine> = Vec::new();
+        let mut current: Vec<CSVLine> = Vec::new();
         current.push(CSVLine {
             url: "url1".to_string(),
-            last_chapter_num: 1.0
+            last_chapter_num: 1.0,
+            title: "title3".to_string(),
         });
         current.push(CSVLine {
             url: "url3".to_string(),
-            last_chapter_num: 3.0
+            last_chapter_num: 3.0,
+            title: "title4".to_string(),
         });
         assert_eq!(imported.get(0), current.get(0));
         let result = find_new_lines(imported.clone(), current.clone());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,33 +1,33 @@
-/// List command logic
-mod list;
 /// Add command logic
 mod add;
-/// Update command logic
-mod update;
 /// Export command logic
 mod export;
 /// Import command logic
 mod import;
-/// Remove command logic
-mod remove;
+/// List command logic
+mod list;
 /// Open command logic
 mod open;
-/// Unread command logic
-mod unread;
+/// Remove command logic
+mod remove;
 /// Restore command logic
 mod undo;
+/// Unread command logic
+mod unread;
+/// Update command logic
+mod update;
 
-use std::path::PathBuf;
-use crate::commands::list::list_chapters;
 use crate::commands::add::add_new_manga;
-use crate::file_ops::create_file;
-use crate::commands::update::update_chapters;
 use crate::commands::export::export_data;
 use crate::commands::import::import_file;
-use crate::commands::remove::remove_manga;
+use crate::commands::list::list_chapters;
 use crate::commands::open::open_manga;
-use crate::commands::unread::unread_chapter;
+use crate::commands::remove::remove_manga;
 use crate::commands::undo::restore_csv;
+use crate::commands::unread::unread_chapter;
+use crate::commands::update::update_chapters;
+use crate::file_ops::write_file::create_file;
+use std::path::PathBuf;
 
 /// Lists the different mangas and their possible updates.
 /// Passes the logic to the list mod.
@@ -36,7 +36,7 @@ use crate::commands::undo::restore_csv;
 /// * `only_new`: will only display new chapters.
 /// * `no_update`: will not update the opened chapter.
 /// * `verbose`: if true, more messages will be shown.
-pub async fn list(file_path: Option<PathBuf>, only_new: bool, no_update: bool, verbose: bool){
+pub async fn list(file_path: Option<PathBuf>, only_new: bool, no_update: bool, verbose: bool) {
     list_chapters(file_path, only_new, no_update, verbose).await
 }
 
@@ -47,9 +47,8 @@ pub async fn list(file_path: Option<PathBuf>, only_new: bool, no_update: bool, v
 pub async fn add(path: Option<PathBuf>, manga_url: Option<String>, verbose: bool) {
     match manga_url {
         Some(url) => add_new_manga(path, url.as_str(), verbose).await,
-        None => println!("An URL is required to be added.")
+        None => println!("An URL is required to be added."),
     }
-
 }
 
 /// Initiates the CSV file to store mangas.
@@ -58,7 +57,7 @@ pub async fn add(path: Option<PathBuf>, manga_url: Option<String>, verbose: bool
 pub fn init(path: Option<PathBuf>) {
     match create_file(&path) {
         Ok(_) => println!("The file has been created, the program is ready to use."),
-        Err(e) => println!("Error creating the file: {}", e)
+        Err(e) => println!("Error creating the file: {}", e),
     }
 }
 
@@ -91,8 +90,12 @@ pub fn export(original_path: Option<PathBuf>, to: Option<PathBuf>) {
 /// * `overwrite`: if true, the destination file will be replaced.
 pub fn import(from: Option<PathBuf>, to: Option<PathBuf>, overwrite: bool, verbose: bool) {
     match import_file(from, to, overwrite, verbose) {
-        Ok(imp) => if imp {println!("The file has been imported.")},
-        Err(e) => eprintln!("Error while importing: {}", e)
+        Ok(imp) => {
+            if imp {
+                println!("The file has been imported.")
+            }
+        }
+        Err(e) => eprintln!("Error while importing: {}", e),
     }
 }
 
@@ -103,7 +106,9 @@ pub fn import(from: Option<PathBuf>, to: Option<PathBuf>, overwrite: bool, verbo
 /// * `verbose`: if true, more messages will be shown.
 pub fn remove(from: Option<PathBuf>, url: Option<String>, verbose: bool) {
     match url {
-        None => println!("No URL provided. Please provide a manganelo URl or a line number to delete."),
+        None => {
+            println!("No URL provided. Please provide a manganelo URl or a line number to delete.")
+        }
         Some(manga_url) => {
             if let Err(e) = remove_manga(from, manga_url.as_str(), verbose) {
                 eprintln!("{}", e)
@@ -122,19 +127,21 @@ pub async fn open(from: Option<PathBuf>, url: Option<String>, direct: bool, verb
     match url {
         None => {
             println!("Usage: open [url/line chapter]. You can open a manga directly by entering the line number as shown with the list command.");
-            println!("Use -d to open the last chapter directly, otherwise, it will open the manga page.")
-        },
-        Some(manga_url) => open_manga(from, manga_url.as_str(), direct, verbose).await
+            println!(
+                "Use -d to open the last chapter directly, otherwise, it will open the manga page."
+            )
+        }
+        Some(manga_url) => open_manga(from, manga_url.as_str(), direct, verbose).await,
     }
 }
 
 pub fn unread(from: Option<PathBuf>, url: Option<String>, verbose: bool) {
     match url {
         None => println!("No number provided. Please provide a line number to reset."),
-        Some(line_number) => unread_chapter(from, line_number.as_str(), verbose)
+        Some(line_number) => unread_chapter(from, line_number.as_str(), verbose),
     }
 }
 
-pub fn undo(from: Option<PathBuf>,verbose: bool) {
+pub fn undo(from: Option<PathBuf>, verbose: bool) {
     restore_csv(from, verbose)
 }

--- a/src/commands/unread.rs
+++ b/src/commands/unread.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
 use crate::file_ops::read_csv;
 use crate::file_ops::write_file::update_csv;
 use crate::models::CSVLine;
+use std::path::PathBuf;
 
 /// Sets a manga to the previous chapter. The url param is the line of the manga to reset.
 /// # Arguments
@@ -12,7 +12,10 @@ pub fn unread_chapter(path: Option<PathBuf>, url: &str, verbose: bool) {
     match read_csv(&path, &verbose) {
         Ok(lines) => {
             if verbose {
-                println!("Trying to parse the expression given ({}) in a number...", url)
+                println!(
+                    "Trying to parse the expression given ({}) in a number...",
+                    url
+                )
             }
             if let Ok(number) = url.parse::<usize>() {
                 if verbose {
@@ -21,11 +24,11 @@ pub fn unread_chapter(path: Option<PathBuf>, url: &str, verbose: bool) {
                 let reset_lines = search_and_reset(&lines, number - 1);
                 match update_csv(&path, reset_lines) {
                     Ok(_) => dark_green_ln!("The manga has been reset to its previous chapter."),
-                    Err(e) => eprintln!("{}", e)
+                    Err(e) => eprintln!("{}", e),
                 }
             }
         }
-        Err(e) => eprintln!("{}", e)
+        Err(e) => eprintln!("{}", e),
     }
 }
 
@@ -45,20 +48,27 @@ fn search_and_reset(lines: &[CSVLine], position: usize) -> Vec<CSVLine> {
 
 /// Searches recursively through the given vector for the position in parameter, and updates said element.
 /// Reconstructs a new vector, and returns it when the current position is at the end of the vector.
-fn inner_search(vec: &[CSVLine], mut new_vec: Vec<CSVLine>, current_pos: usize, to_reset: usize) -> Vec<CSVLine> {
+fn inner_search(
+    vec: &[CSVLine],
+    mut new_vec: Vec<CSVLine>,
+    current_pos: usize,
+    to_reset: usize,
+) -> Vec<CSVLine> {
     if current_pos == vec.len() {
         new_vec
     } else if current_pos == to_reset {
         let line = CSVLine {
             url: vec[current_pos].clone().url,
-            last_chapter_num: vec[current_pos].last_chapter_num - 1f32
+            last_chapter_num: vec[current_pos].last_chapter_num - 1f32,
+            title: vec[current_pos].clone().title,
         };
         new_vec.push(line);
         inner_search(vec, new_vec, current_pos + 1, to_reset)
     } else {
         let line = CSVLine {
             url: vec[current_pos].clone().url,
-            last_chapter_num: vec[current_pos].last_chapter_num
+            last_chapter_num: vec[current_pos].last_chapter_num,
+            title: vec[current_pos].clone().title,
         };
         new_vec.push(line);
         inner_search(vec, new_vec, current_pos + 1, to_reset)
@@ -72,15 +82,18 @@ mod tests {
     fn prepare_lines() -> Vec<CSVLine> {
         let line1 = CSVLine {
             url: String::from("Url1"),
-            last_chapter_num: 3f32
+            last_chapter_num: 3f32,
+            title: "title1".to_string(),
         };
         let line2 = CSVLine {
             url: String::from("Url2"),
-            last_chapter_num: 4f32
+            last_chapter_num: 4f32,
+            title: "title2".to_string(),
         };
         let line3 = CSVLine {
             url: String::from("Url3"),
-            last_chapter_num: 5f32
+            last_chapter_num: 5f32,
+            title: "title3".to_string(),
         };
         let mut lines = Vec::new();
         lines.push(line1);
@@ -94,7 +107,10 @@ mod tests {
         let lines = prepare_lines();
         let reset_lines = search_and_reset(&lines, 1);
         assert_eq!(lines[0].last_chapter_num, reset_lines[0].last_chapter_num);
-        assert_eq!(lines[1].last_chapter_num, reset_lines[1].last_chapter_num + 1f32);
+        assert_eq!(
+            lines[1].last_chapter_num,
+            reset_lines[1].last_chapter_num + 1f32
+        );
         assert_eq!(lines[2].last_chapter_num, reset_lines[2].last_chapter_num);
     }
 
@@ -113,6 +129,9 @@ mod tests {
         let reset_lines = search_and_reset(&lines, 2);
         assert_eq!(lines[0].last_chapter_num, reset_lines[0].last_chapter_num);
         assert_eq!(lines[1].last_chapter_num, reset_lines[1].last_chapter_num);
-        assert_eq!(lines[2].last_chapter_num, reset_lines[2].last_chapter_num + 1f32);
+        assert_eq!(
+            lines[2].last_chapter_num,
+            reset_lines[2].last_chapter_num + 1f32
+        );
     }
 }

--- a/src/file_ops/mod.rs
+++ b/src/file_ops/mod.rs
@@ -2,7 +2,6 @@ pub mod save;
 pub mod write_file;
 
 use crate::models::CSVLine;
-use csv::Writer;
 use std::env::current_exe;
 use std::fs;
 use std::io;
@@ -57,7 +56,7 @@ pub fn read_csv(file_path: &Option<PathBuf>, verbose: &bool) -> Result<Vec<CSVLi
         let headers = reader.headers()?;
         assert!(headers.get(0).unwrap_or("").eq("URL"));
         assert!(headers.get(1).unwrap_or("").eq("Last chapter"));
-        assert!(headers.get(1).unwrap_or("").eq("Title"));
+        assert!(headers.get(2).unwrap_or("").eq("Title"));
     }
 
     for record in reader.records() {
@@ -65,7 +64,7 @@ pub fn read_csv(file_path: &Option<PathBuf>, verbose: &bool) -> Result<Vec<CSVLi
         lines.push(CSVLine {
             url: String::from(rec.get(0).unwrap()),
             last_chapter_num: rec.get(1).unwrap().parse().unwrap(),
-            title: String::from(rec.get(2).unwrap()),
+            title: String::from(rec.get(2).unwrap_or("")),
         })
     }
     if *verbose {
@@ -87,20 +86,6 @@ pub fn is_url_present(file_path: Option<PathBuf>, url: &str) -> Result<bool, io:
     Ok(contents.contains(url))
 }
 
-/// Creates a new CSV file, along with the headers.
-/// The CSv is not customized in terms of separation and line endings.
-/// # Argument:
-/// * `file_path`: the optional file path, if a custom CSV location is used.
-/// # Returns:
-/// Ok if everything went well.
-pub fn create_file(file_path: &Option<PathBuf>) -> Result<(), io::Error> {
-    let path = extract_path_or_default(file_path);
-    let mut wtr = Writer::from_path(path)?;
-    wtr.write_record(&["URL", "Last chapter"])?;
-    wtr.flush()?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,7 +95,7 @@ mod tests {
     #[serial]
     fn test_read_csv() -> Result<(), io::Error> {
         let path = PathBuf::from("mangas.csv");
-        create_file(&Some(path.clone()))?;
+        write_file::create_file(&Some(path.clone()))?;
         let mut to_insert: Vec<CSVLine> = Vec::new();
         to_insert.push(CSVLine {
             url: "url1".to_string(),
@@ -122,6 +107,7 @@ mod tests {
         assert_eq!(inserted.len(), 1);
         assert_eq!(inserted.get(0).unwrap().url, "url1");
         assert_eq!(inserted.get(0).unwrap().last_chapter_num, 0.0);
+        assert_eq!(inserted.get(0).unwrap().title, "title");
         fs::remove_file("mangas.csv")?;
         Ok(())
     }
@@ -130,7 +116,7 @@ mod tests {
     #[serial]
     fn test_is_url_present() -> Result<(), io::Error> {
         let path = PathBuf::from("mangas.csv");
-        create_file(&Some(path.clone()))?;
+        write_file::create_file(&Some(path.clone()))?;
         let mut new_lines: Vec<CSVLine> = Vec::new();
         new_lines.push(CSVLine {
             url: "url1".to_string(),

--- a/src/file_ops/mod.rs
+++ b/src/file_ops/mod.rs
@@ -64,8 +64,8 @@ pub fn read_csv(file_path: &Option<PathBuf>, verbose: &bool) -> Result<Vec<CSVLi
         lines.push(CSVLine {
             url: String::from(rec.get(0).unwrap()),
             last_chapter_num: rec.get(1).unwrap().parse().unwrap(),
-            title: String::from(rec.get(2).unwrap_or("")),
-        })
+            title: String::from(rec.get(2).unwrap()),
+        });
     }
     if *verbose {
         println!("Found {} lines in the CSV.", lines.len());

--- a/src/file_ops/mod.rs
+++ b/src/file_ops/mod.rs
@@ -57,6 +57,7 @@ pub fn read_csv(file_path: &Option<PathBuf>, verbose: &bool) -> Result<Vec<CSVLi
         let headers = reader.headers()?;
         assert!(headers.get(0).unwrap_or("").eq("URL"));
         assert!(headers.get(1).unwrap_or("").eq("Last chapter"));
+        assert!(headers.get(1).unwrap_or("").eq("Title"));
     }
 
     for record in reader.records() {
@@ -64,6 +65,7 @@ pub fn read_csv(file_path: &Option<PathBuf>, verbose: &bool) -> Result<Vec<CSVLi
         lines.push(CSVLine {
             url: String::from(rec.get(0).unwrap()),
             last_chapter_num: rec.get(1).unwrap().parse().unwrap(),
+            title: String::from(rec.get(2).unwrap()),
         })
     }
     if *verbose {
@@ -113,6 +115,7 @@ mod tests {
         to_insert.push(CSVLine {
             url: "url1".to_string(),
             last_chapter_num: 0.0,
+            title: "title".to_string(),
         });
         write_file::update_csv(&Some(path.clone()), to_insert)?;
         let inserted = read_csv(&Some(path), &true)?;
@@ -132,6 +135,7 @@ mod tests {
         new_lines.push(CSVLine {
             url: "url1".to_string(),
             last_chapter_num: 0.0,
+            title: "title".to_string(),
         });
         write_file::update_csv(&Some(path.clone()), new_lines)?;
         assert!(path.exists());

--- a/src/file_ops/save.rs
+++ b/src/file_ops/save.rs
@@ -41,10 +41,16 @@ pub fn restore_file(restore_path: &Option<PathBuf>, verbose: &bool) -> Result<()
     match path.clone().to_str() {
         Some(p) => {
             if !p.ends_with(".csv.bak") {
-                return Err(Error::new(ErrorKind::InvalidInput, "The supplied path is incorrect. The extensions should be .csv.bak."))
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    "The supplied path is incorrect. The extensions should be .csv.bak.",
+                ));
             }
             if !path.is_file() {
-                return Err(Error::new(ErrorKind::Unsupported, "The path should point to the backup CSV file"))
+                return Err(Error::new(
+                    ErrorKind::Unsupported,
+                    "The path should point to the backup CSV file",
+                ));
             }
             let copy_path = &p[0..p.len() - 4];
             fs::copy(path, copy_path)?;
@@ -52,18 +58,21 @@ pub fn restore_file(restore_path: &Option<PathBuf>, verbose: &bool) -> Result<()
                 println!("Restored CSV from {}", p);
             }
             Ok(())
-        },
-        None => Err(Error::new(ErrorKind::InvalidInput, "An error happened while converting the path to String."))
+        }
+        None => Err(Error::new(
+            ErrorKind::InvalidInput,
+            "An error happened while converting the path to String.",
+        )),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
     use crate::file_ops::create_file;
     use crate::file_ops::write_file::update_csv;
     use crate::models::CSVLine;
+    use serial_test::serial;
 
     #[test]
     #[serial]
@@ -74,6 +83,7 @@ mod tests {
         new_lines.push(CSVLine {
             url: "url1".to_string(),
             last_chapter_num: 0.0,
+            title: "title".to_string(),
         });
         update_csv(&Some(path.clone()), new_lines)?;
         assert!(path.exists());
@@ -96,6 +106,7 @@ mod tests {
         new_lines.push(CSVLine {
             url: "url1".to_string(),
             last_chapter_num: 0.0,
+            title: "title".to_string(),
         });
         update_csv(&Some(path.clone()), new_lines)?;
         assert!(path.exists());

--- a/src/file_ops/save.rs
+++ b/src/file_ops/save.rs
@@ -69,7 +69,7 @@ pub fn restore_file(restore_path: &Option<PathBuf>, verbose: &bool) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::file_ops::create_file;
+    use crate::file_ops::write_file::create_file;
     use crate::file_ops::write_file::update_csv;
     use crate::models::CSVLine;
     use serial_test::serial;

--- a/src/file_ops/write_file.rs
+++ b/src/file_ops/write_file.rs
@@ -21,7 +21,7 @@ pub fn update_csv(file_path: &Option<PathBuf>, values: Vec<CSVLine>) -> Result<(
     let file = OpenOptions::new().append(true).open(path)?;
     let mut writer = Writer::from_writer(file);
     for line in values {
-        writer.write_record(&[line.url, line.last_chapter_num.to_string()])?;
+        writer.write_record(&[line.url, line.last_chapter_num.to_string(), line.title])?;
     }
     writer.flush()?;
     Ok(())
@@ -33,6 +33,7 @@ pub fn update_csv(file_path: &Option<PathBuf>, values: Vec<CSVLine>) -> Result<(
 /// * `file_path`: the optional file path, if a custom CSV location is used.
 /// * `url`: The URl to insert (first column).
 /// * `last_chapter`: The chapter to insert (second column)
+/// * `title`: The manga title (thrid column)
 /// # Returns:
 /// Ok if everything went well.
 pub fn append_to_file(
@@ -84,6 +85,8 @@ pub fn export_file(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
     use crate::file_ops::read_csv;
     use serial_test::serial;
@@ -115,9 +118,17 @@ mod tests {
         Ok(())
     }
 
+    fn remove_test_dir() -> Result<(), io::Error> {
+        if Path::new("testDir").exists() {
+            fs::remove_dir_all("testDir")?;
+        }
+        Ok(())
+    }
+
     #[test]
     #[serial]
     fn test_export_file() -> Result<(), io::Error> {
+        remove_test_dir()?;
         let path = PathBuf::from("mangas.csv");
         create_file(&Some(path.clone()))?;
         let mut new_lines: Vec<CSVLine> = Vec::new();
@@ -138,8 +149,7 @@ mod tests {
         assert_eq!(new_file_contents.get(0).unwrap().url, "url1");
         fs::remove_file("mangas.csv")?;
         fs::remove_file("mangas.csv.bak")?;
-        fs::remove_file("testDir/mangas.csv")?;
-        fs::remove_dir("testDir")?;
+        remove_test_dir()?;
         Ok(())
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -11,7 +11,8 @@ pub struct MangaChapter {
 #[derive(Debug, PartialEq, Clone)]
 pub struct CSVLine {
     pub url: String,
-    pub last_chapter_num: f32
+    pub last_chapter_num: f32,
+    pub title: String,
 }
 
 /// Represents a combination of a CSVLine and a MangaChapter, to use where necessary.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,5 @@
-use std::{error, fmt};
 use crate::models::CSVLine;
+use std::{error, fmt};
 
 #[derive(Debug, Clone)]
 pub struct ScraperError {
@@ -23,8 +23,15 @@ impl error::Error for ScraperError {}
 /// # Returns
 /// The vec with the updated value. If the line wasn't present (i.e. if the URL doesn't match), it is unchanged.
 pub fn update_chapter_in_vec(original: Vec<CSVLine>, updated: CSVLine) -> Vec<CSVLine> {
-    original.into_iter()
-        .map(|elt| if elt.url == updated.url { updated.clone() } else { elt } )
+    original
+        .into_iter()
+        .map(|elt| {
+            if elt.url == updated.url {
+                updated.clone()
+            } else {
+                elt
+            }
+        })
         .collect()
 }
 
@@ -35,10 +42,26 @@ mod tests {
     #[test]
     fn update_chapter_in_vec_test() {
         let mut original: Vec<CSVLine> = Vec::new();
-        let line1 = CSVLine { url: "url1".to_string(), last_chapter_num: 0.0 };
-        let line2 = CSVLine { url: "url2".to_string(), last_chapter_num: 1.0 };
-        let line3 = CSVLine { url: "url3".to_string(), last_chapter_num: 2.0 };
-        let new_line2 = CSVLine { url: "url2".to_string(), last_chapter_num: 3.0 };
+        let line1 = CSVLine {
+            url: "url1".to_string(),
+            last_chapter_num: 0.0,
+            title: "title1".to_string(),
+        };
+        let line2 = CSVLine {
+            url: "url2".to_string(),
+            last_chapter_num: 1.0,
+            title: "title2".to_string(),
+        };
+        let line3 = CSVLine {
+            url: "url3".to_string(),
+            last_chapter_num: 2.0,
+            title: "title3".to_string(),
+        };
+        let new_line2 = CSVLine {
+            url: "url2".to_string(),
+            last_chapter_num: 3.0,
+            title: "title2".to_string(),
+        };
         original.push(line1);
         original.push(line2);
         original.push(line3);


### PR DESCRIPTION
### Description
Added the title in the CSV, for when the URL is broken and the manga is unreachable.

### Breaking changes
This change to the CSV makes the CSV **incompatible** between versions.
If your CSV was created before 0.6.10, you'll have to add a new column Title and the title to each line.

### Version
This bumps the version to 0.9.10.